### PR TITLE
Fix CSS path for Next.js layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import './globals.css'
+import '../styles/globals.css'
 import { ReactNode } from 'react'
 
 export const metadata = {


### PR DESCRIPTION
## Summary
- correct reference to `globals.css`

## Testing
- `npm install` *(fails: no output)*
- `npm run build` *(fails: next not found)*